### PR TITLE
Corrects which levels that are prioritized differently

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you want to get more information from the log you'll need to bump up the leve
 Two things:
 
  * You need to set `MinimumLevel` on **both** the Serilog `LoggerConfiguration` and the `ILoggerFactory`
- * Serilog and ASP.NET assign different priorities to the `Debug` and `Trace` levels; Serilog's `Debug` is ASP.NET's `Trace`, and vice-versa
+ * Serilog and ASP.NET assign different priorities to the `Debug` and `Verbose` levels; Serilog's `Debug` is ASP.NET's `Verbose`, and vice-versa
 
 ### Building from source
 


### PR DESCRIPTION
Both Serilog and Framework.Logging have a level called `Verbose` rather than `Trace`.  This corrects the README to reflect this.

For more information on how log levels are prioritized see [Serilog](https://github.com/serilog/serilog/wiki/Writing-Log-Events#log-event-levels) and [Framework.Logging](https://github.com/aspnet/Logging/wiki/Guidelines#log-levels)